### PR TITLE
feat: when generating SVG check that coordinates are not all 0

### DIFF
--- a/__tests__/molecule.js
+++ b/__tests__/molecule.js
@@ -66,6 +66,22 @@ describe('Molecule', () => {
     expect(svg).toContain('stroke-width="2"');
   });
 
+  it('toSVG wrong coordinates (all 0)', () => {
+    const mol = Molecule.fromSmiles('CCOCCO');
+    for (let i = 0; i < mol.getAllAtoms(); i++) {
+      mol.setAtomX(i, 0);
+      mol.setAtomY(i, 0);
+      mol.setAtomZ(i, 0);
+    }
+    let svg = mol.toSVG(300, 150, 'myId');
+    for (let i = 0; i < mol.getAllAtoms(); i++) {
+      expect(mol.getAtomX(i)).toBe(0);
+      expect(mol.getAtomY(i)).toBe(0);
+      expect(mol.getAtomZ(i)).toBe(0);
+    }
+    expect(svg).toContain('width="300px" height="150px"');
+  });
+
   it('toSVG with autoCrop', () => {
     const mol = Molecule.fromSmiles('CCOCCO');
     let svg = mol.toSVG(300, 150, 'myId', { autoCrop: true });

--- a/src/com/actelion/research/gwt/minimal/JSMolecule.java
+++ b/src/com/actelion/research/gwt/minimal/JSMolecule.java
@@ -125,8 +125,23 @@ public class JSMolecule {
 
   private String getSVG(int width, int height, float factorTextSize, boolean autoCrop,
       int autoCropMargin, String id, JavaScriptObject options) {
+
+    boolean degenerated = true;
+    for (int i = 0; i < oclMolecule.getAllAtoms() - 1; i++) {
+      if ((oclMolecule.getAtomX(i) != oclMolecule.getAtomX(i + 1))
+          || (oclMolecule.getAtomY(i) != oclMolecule.getAtomY(i + 1))) {
+        degenerated = false;
+        break;
+      }
+    }
+
+    StereoMolecule mol = degenerated ? oclMolecule.getCompactCopy() : oclMolecule;
+    if (degenerated) {
+      new CoordinateInventor(0).invent(mol);
+    }
+
     int mode = Util.getDisplayMode(options);
-    SVGDepictor d = new SVGDepictor(oclMolecule, mode, id);
+    SVGDepictor d = new SVGDepictor(mol, mode, id);
     d.setFactorTextSize(factorTextSize);
     d.validateView(null, new GenericRectangle(0, 0, width, height),
         AbstractDepictor.cModeInflateToMaxAVBL);


### PR DESCRIPTION
When we generate a SVG we really would like to see a molecule. So if coordinates are missing we do a copy and we generate the coordinates on the copy (don't want to mess us coordinates of the original molecule but maybe this is a mistake).

@targos if you agree with this approach you can merge this PR.