### PR TITLE
fix: do not crash when drag-and-drop comes from toolbar

### DIFF
--- a/src/com/actelion/research/gwt/chemlib/com/actelion/research/chem/SDFileMolecule.java
+++ b/src/com/actelion/research/gwt/chemlib/com/actelion/research/chem/SDFileMolecule.java
@@ -40,6 +40,7 @@ import java.io.ObjectInputStream;
 *
 */
 
+@Deprecated
 public class SDFileMolecule extends StereoMolecule implements java.io.Serializable
 {
     static final long serialVersionUID = 0x2003CAFE;

--- a/src/com/actelion/research/gwt/chemlib/com/actelion/research/share/gui/editor/actions/BondBaseAction.java
+++ b/src/com/actelion/research/gwt/chemlib/com/actelion/research/share/gui/editor/actions/BondBaseAction.java
@@ -79,6 +79,10 @@ public abstract class BondBaseAction extends BondHighlightAction
 
     public boolean onMouseUp(IMouseEvent evt)
     {
+        // Ignore event if the action didn't start in the editor.
+        if (origin == null) {
+            return false;
+        }
 
         boolean ok = true;
         GenericPoint pt = new GenericPoint(evt.getX(), evt.getY());


### PR DESCRIPTION
Closes: https://github.com/cheminfo/openchemlib-js/issues/194