### PR TITLE
feat: also emit change events when in readonly mode

### DIFF
--- a/lib/canvas_editor/init/canvas_editor.js
+++ b/lib/canvas_editor/init/canvas_editor.js
@@ -82,8 +82,6 @@ function initCanvasEditor(
     setOnChangeListener(onChange) {
       this.#checkNotDestroyed();
 
-      if (this.#isReadOnly) return;
-
       this.#onChange = onChange;
     }
 
@@ -120,7 +118,6 @@ function initCanvasEditor(
      * @param {{ what: number; isUserEvent: boolean; }} event
      */
     #handleChange(event) {
-      if (this.#isReadOnly) return;
       if (!this.#onChange) return;
 
       const { what, isUserEvent } = event;

--- a/lib/canvas_editor/init/canvas_editor.js
+++ b/lib/canvas_editor/init/canvas_editor.js
@@ -10,7 +10,6 @@ function initCanvasEditor(
   Reaction,
 ) {
   class CanvasEditor {
-    #isReadOnly;
     #editorArea;
     // Can be useful for debugging.
     /* eslint-disable no-unused-private-class-members */
@@ -22,7 +21,6 @@ function initCanvasEditor(
     #destroy;
 
     constructor(parentElement, options = {}) {
-      const { readOnly = false } = options;
       const { editorArea, toolbar, uiHelper, destroy } = createEditor(
         parentElement,
         options,
@@ -33,7 +31,6 @@ function initCanvasEditor(
         Molecule,
         Reaction,
       );
-      this.#isReadOnly = readOnly;
       this.#editorArea = editorArea;
       this.#toolbar = toolbar;
       this.#uiHelper = uiHelper;


### PR DESCRIPTION
We would like to use the the editor component with disabled editor functionality (readonly=true), while still having the possibility to support dnd and paste operations. Therefore it it is crucial to get those events also in readonly mode.
