### PR TITLE
Expose `moleculeChanged()` in CanvasEditor & CanvasEditorElement

### DIFF
--- a/lib/canvas_editor/init/canvas_editor.js
+++ b/lib/canvas_editor/init/canvas_editor.js
@@ -105,6 +105,12 @@ function initCanvasEditor(
       this.#destroy = null;
     }
 
+    moleculeChanged() {
+      this.#checkNotDestroyed();
+
+      this.#editorArea.getGenericEditorArea().moleculeChanged();
+    }
+
     #checkNotDestroyed() {
       if (!this.#editorArea) {
         throw new Error('CanvasEditor has been destroyed');

--- a/lib/canvas_editor/init/canvas_editor_element.js
+++ b/lib/canvas_editor/init/canvas_editor_element.js
@@ -118,6 +118,13 @@ function initCanvasEditorElement(CanvasEditor, Molecule, ReactionEncoder) {
       this.idcode = '';
     }
 
+    /**
+     * @this {CanvasEditorElement}
+     */
+    moleculeChanged() {
+      this.#editor.moleculeChanged();
+    }
+
     /* --- internals --- */
     /** @type {CanvasEditor} */ #editor;
 


### PR DESCRIPTION
# Expose `moleculeChanged()` in CanvasEditor & CanvasEditorElement

## Overview

This pull request exposes the `moleculeChanged()` method in both the `CanvasEditor` and `CanvasEditorElement`. This change enables an immediate repaint of the editor when updates occur to the underlying molecule, addressing cases where changes are only reflected in the `StereoMolecule` instance and not in the ID code.

## Motivation

In some scenarios, updates to the molecule (e.g. marking bonds as highlighted) do not automatically trigger a visual refresh of the editor. The OCL `GenericEditorArea` includes a `moleculeChanged()` method that triggers a repaint. By exposing this method, we ensure that any changes to the molecule are promptly reflected in the editor's display, thereby improving the overall user experience.

## Changes Made

- **Method Exposure:**  
  The `moleculeChanged()` method has been exposed in the `CanvasEditor` and `CanvasEditorElement`.

- **Repaint Trigger:**  
  The implementation now ensures that when changes occur in the molecule, invoking `moleculeChanged()` will immediately trigger a repaint of the editor.

## Testing

- Verified that updating the `StereoMolecule` instance and invoking `moleculeChanged()` results in an immediate repaint.
