### PR TITLE
fix: expose `moleculeChanged` method from Java

### DIFF
--- a/lib/canvas_editor/init/canvas_editor.js
+++ b/lib/canvas_editor/init/canvas_editor.js
@@ -108,7 +108,7 @@ function initCanvasEditor(
     moleculeChanged() {
       this.#checkNotDestroyed();
 
-      this.#editorArea.getGenericEditorArea().moleculeChanged();
+      this.#editorArea.moleculeChanged();
     }
 
     #checkNotDestroyed() {

--- a/src/com/actelion/research/gwt/gui/generic/JSEditorArea.java
+++ b/src/com/actelion/research/gwt/gui/generic/JSEditorArea.java
@@ -105,7 +105,11 @@ public class JSEditorArea implements GenericCanvas {
   public JSReaction getReaction() {
     return new JSReaction(mDrawArea.getReaction());
   }
- 
+
+  public void moleculeChanged() {
+    mDrawArea.moleculeChanged();
+  }
+
   private native JavaScriptObject getClipboardHandler()
   /*-{
     var jsObject = this.@com.actelion.research.gwt.gui.generic.JSEditorArea::getJsObject()();

--- a/types.d.ts
+++ b/types.d.ts
@@ -3861,6 +3861,12 @@ export declare class CanvasEditor {
   setOnChangeListener(callback: OnChangeListenerCallback): void;
 
   /**
+   * Notify the editor that the molecule has changed (programmatically).
+   * This will trigger a redraw and an onChange event with `isUserEvent=false`.
+   */
+  moleculeChanged(): void;
+
+  /**
    * Remove the change listener callback.
    */
   removeOnChangeListener(): void;


### PR DESCRIPTION
Refs: https://github.com/cheminfo/openchemlib-js/pull/250