### PR TITLE
fix(canvas_editor): avoid blurry rendering on hdpi screens

### DIFF
--- a/lib/canvas_editor/create_editor.js
+++ b/lib/canvas_editor/create_editor.js
@@ -3,6 +3,7 @@ import { getEditorStylesheet } from './editor_stylesheet.js';
 import { addKeyboardListeners, addPointerListeners } from './events.js';
 import { Toolbar } from './toolbar.js';
 import { UIHelper } from './ui_helper.js';
+import { hidpiScaleFactor } from './utils.js';
 
 export function createEditor(
   parentElement,
@@ -88,16 +89,19 @@ export function createEditor(
     ? null
     : new JavaEditorToolbar(editorArea, new Toolbar(toolbarCanvas), uiHelper);
 
-  const containerSize = editorContainer.getBoundingClientRect();
-  editorCanvas.width = containerSize.width;
-  editorCanvas.height = containerSize.height;
+  function updateCanvasDimensions(containerSize) {
+    editorCanvas.style.width = `${containerSize.width}px`;
+    editorCanvas.width = Math.floor(containerSize.width * hidpiScaleFactor);
+    editorCanvas.style.height = `${containerSize.height}px`;
+    editorCanvas.height = Math.floor(containerSize.height * hidpiScaleFactor);
+    editorArea.repaint();
+  }
 
-  editorArea.repaint();
+  const containerSize = editorContainer.getBoundingClientRect();
+  updateCanvasDimensions(containerSize);
 
   const resizeObserver = new ResizeObserver(([entry]) => {
-    editorCanvas.width = entry.contentRect.width;
-    editorCanvas.height = entry.contentRect.height;
-    editorArea.repaint();
+    updateCanvasDimensions(entry.contentRect);
   });
   resizeObserver.observe(editorContainer);
 

--- a/lib/canvas_editor/events.js
+++ b/lib/canvas_editor/events.js
@@ -1,3 +1,5 @@
+import { hidpiScaleFactor } from './utils.js';
+
 /**
  *
  * @param {HTMLCanvasElement} canvasElement
@@ -16,8 +18,8 @@ export function addPointerListeners(canvasElement, drawArea, JavaEditorArea) {
       what,
       ev.button + 1,
       clickCount,
-      Math.round(ev.offsetX),
-      Math.round(ev.offsetY),
+      Math.round(ev.offsetX * hidpiScaleFactor),
+      Math.round(ev.offsetY * hidpiScaleFactor),
       ev.shiftKey,
       ev.ctrlKey,
       ev.altKey,

--- a/lib/canvas_editor/toolbar.js
+++ b/lib/canvas_editor/toolbar.js
@@ -1,4 +1,5 @@
 import { DrawContext } from './draw_context.js';
+import { hidpiScaleFactor } from './utils.js';
 
 export class Toolbar {
   constructor(canvasElement) {
@@ -8,7 +9,9 @@ export class Toolbar {
 
   setDimensions(width, height) {
     this.canvasElement.width = width;
+    this.canvasElement.style.width = `${width / hidpiScaleFactor}px`;
     this.canvasElement.height = height;
+    this.canvasElement.style.height = `${height / hidpiScaleFactor}px`;
   }
 
   getDrawContext() {

--- a/lib/canvas_editor/utils.js
+++ b/lib/canvas_editor/utils.js
@@ -46,3 +46,5 @@ export function decodeBase64(base64) {
 export function toHex(v) {
   return v.toString(16).padStart(2, '0');
 }
+
+export const hidpiScaleFactor = globalThis.devicePixelRatio || 1;

--- a/scripts/openchemlib/modified/com/actelion/research/gui/hidpi/HiDPIHelper.java
+++ b/scripts/openchemlib/modified/com/actelion/research/gui/hidpi/HiDPIHelper.java
@@ -7,17 +7,22 @@ import com.actelion.research.util.ColorHelper;
 import java.awt.Color;
 
 public class HiDPIHelper {
+	private static float sUIScaleFactor = -1f;
+
 	public static int scale(float value) {
 		return Math.round(getUIScaleFactor() * value);
 	}
 
 	public static float getUIScaleFactor() {
-		return 1.0f;
+		if (sUIScaleFactor == -1) {
+			sUIScaleFactor = getDevicePixelRatio();
+		}
+		return sUIScaleFactor;
 	}
 
-	public static void adaptForLookAndFeel(GenericImage image) {
-		return;
-	}
+	private static native float getDevicePixelRatio() /*-{
+		return globalThis.devicePixelRatio || 1;
+	}-*/;
 
 	public static void disableImage(GenericImage image) {
 		Color gray = ColorHelper.brighter(new Color(238, 238, 238), 0.8f);

--- a/src/com/actelion/research/gwt/chemlib/com/actelion/research/gui/hidpi/HiDPIHelper.java
+++ b/src/com/actelion/research/gwt/chemlib/com/actelion/research/gui/hidpi/HiDPIHelper.java
@@ -7,17 +7,22 @@ import com.actelion.research.util.ColorHelper;
 import java.awt.Color;
 
 public class HiDPIHelper {
+	private static float sUIScaleFactor = -1f;
+
 	public static int scale(float value) {
 		return Math.round(getUIScaleFactor() * value);
 	}
 
 	public static float getUIScaleFactor() {
-		return 1.0f;
+		if (sUIScaleFactor == -1) {
+			sUIScaleFactor = getDevicePixelRatio();
+		}
+		return sUIScaleFactor;
 	}
 
-	public static void adaptForLookAndFeel(GenericImage image) {
-		return;
-	}
+	private static native float getDevicePixelRatio() /*-{
+		return globalThis.devicePixelRatio || 1;
+	}-*/;
 
 	public static void disableImage(GenericImage image) {
 		Color gray = ColorHelper.brighter(new Color(238, 238, 238), 0.8f);


### PR DESCRIPTION
Closes: https://github.com/cheminfo/openchemlib-js/issues/272

You can test with "virtual" zoom in the browser using <kbd>Ctrl</kbd><kbd>+</kbd>

I confirm it also looks much better on my iPad.

Before (on Macbook retina display): https://5ac78be9.openchemlib-js.pages.dev/examples/
![CleanShot 2025-05-01 at 11 08 41@2x](https://github.com/user-attachments/assets/436bbf1a-46cc-4275-be1f-344dce653010)

After: https://2a479b8c.openchemlib-js.pages.dev/examples/
![CleanShot 2025-05-01 at 11 09 00@2x](https://github.com/user-attachments/assets/aad9bf47-5acb-4116-b2ac-2e1a92d8af80)
