### PR TITLE
fix: use head prepend instead mutate possibly external stylesheet

### DIFF
--- a/lib/canvas_editor/init/index.js
+++ b/lib/canvas_editor/init/index.js
@@ -31,27 +31,20 @@ export default function init(OCL) {
 
     customElements.define('openchemlib-editor', CanvasEditorElement);
 
-    // mutate the first stylesheet available or construct a new one, added to adoptedStyleSheets
-    // It's default styling for openchemlib-editor element,
+    // Add new stylesheet (prepend to the head)
+    // It's the default styling for openchemlib-editor element,
     // should be considered as a user-agent stylesheet (low-priority)
-    const css =
-      document.styleSheets[0] ??
-      (() => {
-        const css = new CSSStyleSheet();
-        document.adoptedStyleSheets.unshift(css);
-        return css;
-      })();
-    css.insertRule(
-      `
-      /* dynamicaly added from openchemlib registerCustomElement with low priority */
-      openchemlib-editor:defined {
-        display: block;
-        height: 400px;
-        width: 600px;
-      }
-      `,
-      0,
-    );
+    const style = document.createElement('style');
+    style.id = 'openchemlib-editor-default-style';
+    style.innerHTML = `
+    /* dynamicaly added from openchemlib registerCustomElement with low priority */
+    openchemlib-editor:defined {
+      display: block;
+      height: 400px;
+      width: 600px;
+    }
+    `;
+    document.head.prepend(style);
 
     return CanvasEditorElement;
   }

--- a/scripts/get-gwt.sh
+++ b/scripts/get-gwt.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# clear previous gwt installation
+rm -rf gwt
+
 wget -q https://github.com/gwtproject/gwt/releases/download/2.12.2/gwt-2.12.2.zip -O gwt.zip
 unzip -q gwt.zip
 mv gwt-2* gwt

--- a/scripts/get-java.sh
+++ b/scripts/get-java.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# clear previous jdk installation
+rm -rf jdk
+
 wget -q https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.6%2B7/OpenJDK21U-jdk_x64_linux_hotspot_21.0.6_7.tar.gz -O jdk.tar.gz
 tar xf jdk.tar.gz
 mv jdk-21* jdk


### PR DESCRIPTION
mutate external stylesheets can raise error like  
Uncaught DOMException: CSSStyleSheet.insertRule: Not allowed to access cross-origin stylesheet

* fix: download gwt and jdk scripts. old folders need to be deleted before `mv` command

Closes: https://github.com/cheminfo/openchemlib-js/issues/288