### PR TITLE
fix(canvas_editor): do not repaint editor when its size is zero

### DIFF
--- a/lib/canvas_editor/create_editor.js
+++ b/lib/canvas_editor/create_editor.js
@@ -94,7 +94,13 @@ export function createEditor(
     editorCanvas.width = Math.floor(containerSize.width * hidpiScaleFactor);
     editorCanvas.style.height = `${containerSize.height}px`;
     editorCanvas.height = Math.floor(containerSize.height * hidpiScaleFactor);
-    editorArea.repaint();
+
+    // Do not repaint when the size is zero (there would be nothing to see anyway).
+    // This can happen when the editor is hidden with `display: none` and breaks
+    // the rendering on Chrome-based browsers.
+    if (containerSize.width > 0 && containerSize.height > 0) {
+      editorArea.repaint();
+    }
   }
 
   const containerSize = editorContainer.getBoundingClientRect();


### PR DESCRIPTION
Closes: https://github.com/NPellet/visualizer/issues/1162
