### PR TITLE
feat: allow to identify root div of CanvasEditor

### DIFF
--- a/lib/canvas_editor/create_editor.js
+++ b/lib/canvas_editor/create_editor.js
@@ -22,6 +22,9 @@ export function createEditor(
   } = options;
 
   const rootElement = document.createElement('div');
+
+  rootElement.dataset.openchemlibCanvasEditor = 'true';
+
   Object.assign(rootElement.style, {
     width: '100%',
     height: '100%',


### PR DESCRIPTION
add `data-openchemlib-canvas-editor` attribute to the root editor div so it can easily be recognized, for example in an event listener
