### PR TITLE
feat: expose MCS (maximum common substructure)

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3655,6 +3655,60 @@ export declare class SSSearcherWithIndex {
   createIndex(molecule: Molecule): number[];
 }
 
+export type MCSRingMatchMode =
+  | 'cleaveRings'
+  | 'keepRings'
+  | 'keepAromaticRings';
+
+export interface MCSOptions {
+  /**
+   * How rings of the fragment are handled when building common substructures.
+   * - `cleaveRings`: rings may be broken, so a partial ring can be part of the result.
+   * - `keepRings`: a ring is only kept if it is entirely part of the common substructure.
+   * - `keepAromaticRings`: same as `keepRings` but restricted to aromatic rings.
+   * @default 'cleaveRings'
+   */
+  ringMatchMode?: MCSRingMatchMode;
+}
+
+/**
+ * Computes the maximum common substructure (MCS) between two molecules.
+ */
+export declare class MCS {
+  /**
+   * Creates a new maximum common substructure finder.
+   */
+  constructor(options?: MCSOptions);
+
+  /**
+   * Sets the pair of molecules to compare. `molecule` should contain at least
+   * as many bonds as `fragment`. If `fragment` contains more than one disconnected
+   * structure, only the biggest one is considered.
+   * @param molecule - the (usually larger) target molecule.
+   * @param fragment - the molecule whose common substructure with `molecule` is searched.
+   */
+  set(molecule: Molecule, fragment: Molecule): void;
+
+  /**
+   * Returns the maximum common substructure as a `Molecule`, or `null` if no
+   * common substructure was found.
+   */
+  getMCS(): Molecule | null;
+
+  /**
+   * Returns the score of the maximum common substructure, defined as the number
+   * of bonds of the MCS divided by the larger bond count of the two input molecules.
+   * `getMCS()` (or `getAllCommonSubstructures()`) must be called first.
+   */
+  getScore(): number;
+
+  /**
+   * Returns all distinct common substructures (the largest first), or `null` if
+   * none was found.
+   */
+  getAllCommonSubstructures(): Molecule[] | null;
+}
+
 export declare class Transformer {
   constructor(reactant: Molecule, product: Molecule, name: string);
   setMolecule(molecule: Molecule, countMode: number): number;

--- a/lib/index.debug.js
+++ b/lib/index.debug.js
@@ -19,6 +19,7 @@ export const ConformerGenerator = OCL.ConformerGenerator;
 export const DrugScoreCalculator = OCL.DrugScoreCalculator;
 export const DruglikenessPredictor = OCL.DruglikenessPredictor;
 export const ForceFieldMMFF94 = OCL.ForceFieldMMFF94;
+export const MCS = OCL.MCS;
 export const Molecule = OCL.Molecule;
 export const MoleculeProperties = OCL.MoleculeProperties;
 export const Reaction = OCL.Reaction;

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ export const ConformerGenerator = OCL.ConformerGenerator;
 export const DrugScoreCalculator = OCL.DrugScoreCalculator;
 export const DruglikenessPredictor = OCL.DruglikenessPredictor;
 export const ForceFieldMMFF94 = OCL.ForceFieldMMFF94;
+export const MCS = OCL.MCS;
 export const Molecule = OCL.Molecule;
 export const MoleculeProperties = OCL.MoleculeProperties;
 export const Reaction = OCL.Reaction;

--- a/src/com/actelion/research/gwt/js/api/JSMCS.java
+++ b/src/com/actelion/research/gwt/js/api/JSMCS.java
@@ -1,0 +1,58 @@
+package com.actelion.research.gwt.js.api;
+
+import com.actelion.research.chem.StereoMolecule;
+import com.actelion.research.chem.mcs.MCS;
+import com.google.gwt.core.client.JavaScriptObject;
+import java.util.LinkedList;
+import jsinterop.annotations.*;
+
+@JsType(name = "MCS")
+public class JSMCS {
+  private MCS mcs;
+
+  public JSMCS(JavaScriptObject options) {
+    int ringStatus = getRingStatus(options);
+    mcs = new MCS(ringStatus);
+  }
+
+  private native int getRingStatus(JavaScriptObject options)
+  /*-{
+    options = options || {};
+    var ringMatchMode = options.ringMatchMode || 'cleaveRings';
+    switch (ringMatchMode) {
+      case 'cleaveRings': return @com.actelion.research.chem.mcs.MCS::PAR_CLEAVE_RINGS;
+      case 'keepRings': return @com.actelion.research.chem.mcs.MCS::PAR_KEEP_RINGS;
+      case 'keepAromaticRings': return @com.actelion.research.chem.mcs.MCS::PAR_KEEP_AROMATIC_RINGS;
+      default: throw new Error('invalid ring match mode: ' + ringMatchMode);
+    }
+  }-*/;
+
+  public void set(JSMolecule molecule, JSMolecule fragment) {
+    this.mcs.set(molecule.getStereoMolecule(), fragment.getStereoMolecule());
+  }
+
+  public JSMolecule getMCS() {
+    StereoMolecule result = this.mcs.getMCS();
+    if (result == null) {
+      return null;
+    }
+    return new JSMolecule(result);
+  }
+
+  public double getScore() {
+    return this.mcs.getScore();
+  }
+
+  public JSMolecule[] getAllCommonSubstructures() {
+    LinkedList<StereoMolecule> list = this.mcs.getAllCommonSubstructures();
+    if (list == null) {
+      return null;
+    }
+    JSMolecule[] result = new JSMolecule[list.size()];
+    int index = 0;
+    for (StereoMolecule substructure : list) {
+      result[index++] = new JSMolecule(substructure);
+    }
+    return result;
+  }
+}

--- a/tests/__snapshots__/library.test.ts.snap
+++ b/tests/__snapshots__/library.test.ts.snap
@@ -51,6 +51,15 @@ exports[`class prototypes > prototype properties of ForceFieldMMFF94 1`] = `
 ]
 `;
 
+exports[`class prototypes > prototype properties of MCS 1`] = `
+[
+  "getAllCommonSubstructures",
+  "getMCS",
+  "getScore",
+  "set",
+]
+`;
+
 exports[`class prototypes > prototype properties of Molecule 1`] = `
 [
   "addAtom",
@@ -485,6 +494,8 @@ exports[`class prototypes > static properties of ForceFieldMMFF94 1`] = `
 ]
 `;
 
+exports[`class prototypes > static properties of MCS 1`] = `[]`;
+
 exports[`class prototypes > static properties of Molecule 1`] = `
 [
   "CANONIZER_ASSIGN_PARITIES_TO_TETRAHEDRAL_N",
@@ -834,6 +845,7 @@ exports[`top-level API 1`] = `
   "DrugScoreCalculator",
   "DruglikenessPredictor",
   "ForceFieldMMFF94",
+  "MCS",
   "Molecule",
   "MoleculeProperties",
   "Reaction",

--- a/tests/mcs/mcs.test.ts
+++ b/tests/mcs/mcs.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { MCS, Molecule } from '#lib';
+
+describe('MCS', () => {
+  it('finds the common substructure of two molecules', () => {
+    const mcs = new MCS();
+    mcs.set(
+      Molecule.fromSmiles('c1ccccc1CCO'),
+      Molecule.fromSmiles('c1ccccc1CCN'),
+    );
+
+    const common = mcs.getMCS();
+
+    expect(common).not.toBeNull();
+    // The shared scaffold is the ethylbenzene part (8 atoms, no oxygen/nitrogen).
+    expect(common?.getAllAtoms()).toBe(8);
+
+    const score = mcs.getScore();
+
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThanOrEqual(1);
+  });
+
+  it('returns the full molecule when one is a substructure of the other', () => {
+    const mcs = new MCS();
+    mcs.set(
+      Molecule.fromSmiles('c1ccccc1CCO'),
+      Molecule.fromSmiles('c1ccccc1'),
+    );
+
+    const common = mcs.getMCS();
+
+    expect(common?.getAllAtoms()).toBe(6);
+    // Score is the MCS bond count (benzene: 6) divided by the larger molecule's
+    // bond count (phenethyl alcohol: 9).
+    expect(mcs.getScore()).toBeCloseTo(6 / 9);
+  });
+
+  it('lists all common substructures', () => {
+    // The two molecules differ only at the linker atom (O vs N). On each side of
+    // that atom sits a distinct ring system, so two separate common substructures
+    // are found: the benzene side and the pyridine side.
+    const mcs = new MCS();
+    mcs.set(
+      Molecule.fromSmiles('c1ccccc1CCOCc1ccncc1'),
+      Molecule.fromSmiles('c1ccccc1CCNCc1ccncc1'),
+    );
+
+    const all = mcs.getAllCommonSubstructures();
+
+    expect(all).not.toBeNull();
+
+    const idCodes = all?.map((molecule) => molecule.getIDCode()).toSorted();
+
+    expect(idCodes).toStrictEqual(
+      [
+        'daD@@DjUZxHH@B', // ethylbenzene fragment (8 atoms)
+        'gOx@@eJyh@PA@', // methylpyridine fragment (7 atoms)
+      ].toSorted(),
+    );
+  });
+});


### PR DESCRIPTION
## What

Exposes OpenChemLib's `MCS` class to JS/TS. The `MCS` class was already vendored in the OCL Java source but had no JS wrapper, export, or type definition.

## API

```js
import { MCS, Molecule } from 'openchemlib';

const mcs = new MCS({ ringMatchMode: 'cleaveRings' }); // 'cleaveRings' | 'keepRings' | 'keepAromaticRings'
mcs.set(Molecule.fromSmiles('c1ccccc1CCO'), Molecule.fromSmiles('c1ccccc1CCN'));

mcs.getMCS();                    // Molecule | null
mcs.getScore();                  // MCS bonds / max(bond count of the two inputs)
mcs.getAllCommonSubstructures(); // Molecule[] | null
```

- `set(molecule, fragment)` — `molecule` must contain at least as many bonds as `fragment`.
- `getScore()` must be called after `getMCS()` (it relies on the computed MCS).

## Changes

- New `JSMCS.java` wrapper (`@JsType(name = "MCS")`), following the `JSSSSearcher` pattern.
- Exported `MCS` from `lib/index.js` / `lib/index.debug.js`.
- Type definitions in `lib/index.d.ts` (`MCS`, `MCSOptions`, `MCSRingMatchMode`).
- Tests in `tests/mcs/mcs.test.ts` with exact-idcode assertions.
- Updated the top-level API snapshot.

GWT recompiled (min + debug); full suite passes (243 tests), check-types / eslint / prettier clean.